### PR TITLE
rename decorateApp to addAsync, add decorateApp/Router aliases

### DIFF
--- a/HEADER.md
+++ b/HEADER.md
@@ -5,7 +5,7 @@ Write Express middleware and route handlers using async/await
 # Usage
 
 ```javascript
-const { decorateApp } = require('@awaitjs/express');
+const { addAsync } = require('@awaitjs/express');
 
 // Or, if you want to use `wrap()`
 const { wrap } = require('@awaitjs/express');

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Write Express middleware and route handlers using async/await
 # Usage
 
 ```javascript
-const { decorateApp } = require('@awaitjs/express');
+const { addAsync } = require('@awaitjs/express');
 
 // Or, if you want to use `wrap()`
 const { wrap } = require('@awaitjs/express');
@@ -14,10 +14,10 @@ const { wrap } = require('@awaitjs/express');
 
 # API
 
-## decorateApp()
+## addAsync()
 
 
-The `decorateApp()` function is the preferred way to add async/await
+The `addAsync()` function is the preferred way to add async/await
 support to your Express app. This function adds several helper functions
 to your Express app.
 
@@ -25,13 +25,13 @@ to your Express app.
 ### It adds `useAsync()`, `getAsync()`, etc. to your Express app
 
 
-The `decorateApp()` function adds `useAsync()`, `getAsync()`, `patchAsync()`,
+The `addAsync()` function adds `useAsync()`, `getAsync()`, `patchAsync()`,
 `putAsync()`, `postAsync()`, `deleteAsync()` and `headAsync()`.
 
 
 ```javascript
 const express = require('express');
-const app = decorateApp(express());
+const app = addAsync(express());
 
 // `useAsync()` is like `app.use()`, but supports async functions
 app.useAsync(async function(req, res, next) {
@@ -44,7 +44,7 @@ app.getAsync('*', async function(req, res, next) {
 });
 
 // Because of `getAsync()`, this error handling middleware will run.
-// `decorateApp()` also enables async error handling middleware.
+// `addAsync()` also enables async error handling middleware.
 app.use(function(error, req, res, next) {
   res.send(error.message);
 });
@@ -52,10 +52,20 @@ app.use(function(error, req, res, next) {
 const server = await app.listen(3000);
 ```
 
+## decorateApp()
+The `decorateApp()` function is an alias for addAsync. Alias avoids
+a breaking change.
+
+
+## decorateRouter()
+The `decorateRouter()` function is also an alias for addAsync.
+Alias is for those who prefer using decorateApp, but think
+it's confusing to use decorateApp with express.Router
+
 ## wrap()
 
 
-If you need more fine-grained control than what `decorateApp()` gives
+If you need more fine-grained control than what `addAsync()` gives
 you, you can use the `wrap()` function. This function wraps an async
 Express middleware or route handler for better error handling.
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 const assert = require('assert');
 
 module.exports = {
-  decorateApp: decorateApp,
-  wrap: wrap
+  addAsync,
+  decorateApp: addAsync,
+  decorateRouter: addAsync,
+  wrap
 };
 
-function decorateApp(app) {
+function addAsync(app) {
   app.useAsync = function() {
     const fn = arguments[arguments.length - 1];
     assert.ok(typeof fn === 'function',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
 const express = require('express');
 const superagent = require('superagent');
-const { decorateApp, wrap } = require('../');
+const { addAsync, wrap } = require('../');
 
-describe('decorateApp', function() {
+describe('addAsync', function() {
   it('works', async function() {
-    const app = decorateApp(express());
+    const app = addAsync(express());
 
     app.useAsync(async function(req, res, next) {
       throw new Error('Oops!');

--- a/test/readme.test.js
+++ b/test/readme.test.js
@@ -1,21 +1,21 @@
 const assert = require('assert');
-const { decorateApp, wrap } = require('../');
+const { addAsync, decorateApp, decorateRouter, wrap } = require('../');
 const superagent = require('superagent');
 
 describe('API', function() {
   /**
-   * The `decorateApp()` function is the preferred way to add async/await
+   * The `addAsync()` function is the preferred way to add async/await
    * support to your Express app. This function adds several helper functions
    * to your Express app.
    */
-  describe('decorateApp()', function() {
+  describe('addAsync()', function() {
     /**
-     * The `decorateApp()` function adds `useAsync()`, `getAsync()`,
+     * The `addAsync()` function adds `useAsync()`, `getAsync()`,
      * `putAsync()`, `postAsync()`, and `headAsync()`.
      */
     it('adds `useAsync()`, `getAsync()`, etc. to your Express app', async function() {
       const express = require('express');
-      const app = decorateApp(express());
+      const app = addAsync(express());
 
       // `useAsync()` is like `app.use()`, but supports async functions
       app.useAsync(async function(req, res, next) {
@@ -28,7 +28,7 @@ describe('API', function() {
       });
 
       // Because of `getAsync()`, this error handling middleware will run.
-      // `decorateApp()` also enables async error handling middleware.
+      // `addAsync()` also enables async error handling middleware.
       app.use(function(error, req, res, next) {
         res.send(error.message);
       });
@@ -44,8 +44,20 @@ describe('API', function() {
     });
   });
 
+  describe('decorateApp', function() {
+    it('is an alias for addAsync()', function() {
+      assert.equal(decorateApp, addAsync)
+    });
+  });
+
+  describe('decorateRouter', function() {
+    it('is an alias for addAsync()', function() {
+      assert.equal(decorateRouter, addAsync)
+    });
+  });
+
   /**
-   * If you need more fine-grained control than what `decorateApp()` gives
+   * If you need more fine-grained control than what `addAsync()` gives
    * you, you can use the `wrap()` function. This function wraps an async
    * Express middleware or route handler for better error handling.
    */


### PR DESCRIPTION
Made some updates, based on feedback in https://github.com/vkarpov15/awaitjs-express/issues/1