### PR TITLE
Add Router to TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Express, Router, IRouter } from 'express'
+import { Express, Router, IRouter, RouterOptions } from 'express'
 
 export interface IRouterWithAsync {
   useAsync: IRouter['use']
@@ -19,3 +19,6 @@ export { addAsync }
 
 export const decorateRouter: (router: Router) => RouterWithAsync
 export const decorateApp: (router: Express) => ExpressWithAsync
+
+declare function AsyncRouter(options?: RouterOptions): RouterWithAsync
+export { AsyncRouter as Router }


### PR DESCRIPTION
I like the new `Router()` export a lot; it's really useful. However, it seems to be missing from the recently added TypeScript definitions file, so I've added it here. I'm new to TypeScript so I hope I did it correctly!

There's one problem: I think `@types/express` might need to be installed for this to work. Seems like the options are to install it here as an optional peer dependency, or to move the definitions file out of this project and into a package in the `@types` org, where it can pull in other types easily. Again, I'm just learning TS so not sure what the preferred choice would be. Let me know if you have feedback.

Thanks for this very convenient little package!