### PR TITLE
Reflect changed function signatures in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,25 @@
-import { Express, Router, IRouter, RouterOptions } from 'express'
+import { Express, Router, RouterOptions } from 'express'
+import type { Request, Response, ParamsDictionary, NextFunction, IRouter as _IRouter } from 'express-serve-static-core';
+import type { ParsedQs } from 'qs';
+
+// copied from express-serve-static-core so we can change the function signature
+export interface RequestHandler<
+    P = ParamsDictionary,
+    ResBody = any,
+    ReqBody = any,
+    ReqQuery = ParsedQs,
+    Locals extends Record<string, any> = Record<string, any>
+> {
+    // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2)
+    (
+        req: Request<P, ResBody, ReqBody, ReqQuery, Locals>,
+        res: Response<ResBody, Locals>,
+        next: NextFunction,
+    ): Promise<void>;
+}
+
+interface IRouter extends RequestHandler, _IRouter {
+}
 
 export interface IRouterWithAsync {
   useAsync: IRouter['use']

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "git://github.com/vkarpov15/awaitjs-express.git"
   },
   "devDependencies": {
+    "@types/express-serve-static-core": "^4.17.19",
     "acquit": "1.0.0",
     "acquit-ignore": "0.1.0",
     "acquit-markdown": "0.1.0",


### PR DESCRIPTION
The types for `useAsync` et al don’t reflect the fact that the handlers can return promises, since they directly use the Express types. The line:
```typescript
    server.useAsync("/admin/new/", async (_req, res) => {
```
Causes a lint error, because TypeScript itself won’t complain (as it’s somewhat lax about parameters) but it’s technically incorrect:
```text
  57:36  error  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
```
This PR fixes that, in a slightly hacky way.